### PR TITLE
Smooth templates

### DIFF
--- a/configs/harvestDatacards.yml
+++ b/configs/harvestDatacards.yml
@@ -1,4 +1,4 @@
-input_folder: "./"
+input_folder: "/vols/cms/dw515/CH_CP_Run3/CMSSW_14_1_0_pre4/src/CombineHarvester/Combine_HtautauCP/cpdatacards/"
 output_folder: "outputs/"
 channels: "all"
 merge_mode: 2

--- a/configs/harvestDatacards.yml
+++ b/configs/harvestDatacards.yml
@@ -1,4 +1,4 @@
-input_folder: "/vols/cms/lcr119/offline/HiggsCP/TIDAL/Draw/cpdatacards/"
+input_folder: "./"
 output_folder: "outputs/"
 channels: "all"
-mergeSymBins: False
+merge_mode: 2

--- a/scripts/convertCards.py
+++ b/scripts/convertCards.py
@@ -1,0 +1,182 @@
+import ROOT
+import math
+import argparse
+ROOT.TH1.AddDirectory(False)
+from ctypes import c_double
+ 
+# note that the merging of bins requires an even numnber of phi_CP bins, and this number must be set to the specific value used in the dictionary below otherwise the method will give incorrect results!
+
+cp_bins = {
+        "tt_mva_fake": 1,
+        "tt_mva_tau": 1,
+        "tt_mva_higgs": 1,
+        "tt_higgs_pia1" : 4,
+        "tt_higgs_a11pra1" : 4,
+        "tt_higgs_rhoa1" : 4,
+        "tt_higgs_pia11pr" : 4,
+        "tt_higgs_pirho" : 10,
+        "tt_higgs_a1a1" : 4,
+        "tt_higgs_pipi" : 4,
+        "tt_higgs_rhoa11pr" : 4,
+        "tt_higgs_rhorho" : 10,
+}
+
+def MergeXBins(hist, nxbins):
+  histnew = hist.Clone()
+  nbins = hist.GetNbinsX()
+  for i in range(1,nbins+1,nxbins):
+    tot_err = c_double(0)
+    tot = hist.IntegralAndError(i,i+nxbins-1,tot_err)
+    tot_err = tot_err.value
+    for j in range(i,i+nxbins):
+      histnew.SetBinContent(j,tot/nxbins)
+      histnew.SetBinError(j,tot_err/nxbins)
+  return histnew
+
+def Symmetrise(hist,nxbins):
+  histnew=hist.Clone()
+  nbins = hist.GetNbinsX()
+  if nbins % 2:
+    print('N X bins in 2D histogram is not even so cannot symmetrise!')
+    return
+  nybins = int(nbins/nxbins)
+  for i in range(1,int(nxbins/2)+1):
+    lo_bin = i
+    hi_bin = nxbins-i+1
+    for j in range(1,nybins+1):
+      lo_bin_ = lo_bin+(j-1)*nxbins
+      hi_bin_ = hi_bin+(j-1)*nxbins
+      c1 = hist.GetBinContent(lo_bin_)
+      c2 = hist.GetBinContent(hi_bin_)
+      e1 = hist.GetBinError(lo_bin_)
+      e2 = hist.GetBinError(hi_bin_)
+      cnew = (c1+c2)/2
+      enew = math.sqrt(e1**2 + e2**2)/2
+      histnew.SetBinContent(lo_bin_,cnew)
+      histnew.SetBinContent(hi_bin_,cnew)
+      histnew.SetBinError(lo_bin_,enew)
+      histnew.SetBinError(hi_bin_,enew)
+  return histnew
+
+def ASymmetrise(hist,hsm,hps,nxbins):
+  histnew=hist.Clone()
+  hsub=hsm.Clone()
+  hsub.Add(hps)
+  hsub.Scale(0.5)
+  for i in range(1,hsub.GetNbinsX()+1): 
+    histnew.SetBinContent(i,histnew.GetBinContent(i)-hsub.GetBinContent(i))
+
+  nbins = hist.GetNbinsX()
+  if nbins % 2:
+    print('N X bins in 2D histogram is not even so cannot symmetrise!')
+    return
+  nybins = int(nbins/nxbins)
+  for i in range(1,int(nxbins/2)+1):
+    lo_bin = i
+    hi_bin = nxbins-i+1
+    for j in range(1,nybins+1):
+      lo_bin_ = lo_bin+(j-1)*nxbins
+      hi_bin_ = hi_bin+(j-1)*nxbins
+
+      mmi = hist.GetBinContent(lo_bin_)       
+      mmj = hist.GetBinContent(hi_bin_)       
+      smi = hsm.GetBinContent(lo_bin_) 
+      smj = hsm.GetBinContent(hi_bin_)
+      psi = hps.GetBinContent(lo_bin_)
+      psj = hps.GetBinContent(hi_bin_)
+
+      e_mmi = hist.GetBinError(lo_bin_)
+      e_mmj = hist.GetBinError(hi_bin_)
+      e_smi = hsm.GetBinError(lo_bin_)
+      e_smj = hsm.GetBinError(hi_bin_)
+      e_psi = hps.GetBinError(lo_bin_)
+      e_psj = hps.GetBinError(hi_bin_) 
+
+      c1_new = ( smj+psj-mmj + mmi)/2
+      c2_new = ( smi+psi-mmi + mmj)/2
+
+      e1_new = math.sqrt((e_smj+e_psj-e_mmj)**2 + e_mmi**2)/2 
+      e2_new = math.sqrt((e_smi+e_psi-e_mmi)**2 + e_mmj**2)/2 
+
+      histnew.SetBinContent(lo_bin_,c1_new)
+      histnew.SetBinContent(hi_bin_,c2_new)
+      histnew.SetBinError(lo_bin_,e1_new)
+      histnew.SetBinError(hi_bin_,e2_new)
+
+  return histnew
+
+def getHistogramAndWriteToFile(infile,outfile,dirname,write_dirname):
+    directory = infile.Get(dirname)
+    for key in directory.GetListOfKeys():
+        histo = directory.Get(key.GetName())
+        if isinstance(histo,ROOT.TH1D) or isinstance(histo,ROOT.TH1F):
+            print('Processing:', dirname, histo.GetName()) 
+            if dirname in cp_bins: nxbins = cp_bins[dirname]
+            else: nxbins=1
+
+            # we write all the old histograms to the output file
+            outfile.cd()
+            if not ROOT.gDirectory.GetDirectory(dirname): ROOT.gDirectory.mkdir(dirname)
+            ROOT.gDirectory.cd(dirname)
+            histo.Write()
+
+            if nxbins== 1: continue
+
+            # if data we skip
+            if 'data_obs' in key.GetName(): continue
+
+            # if mm signal then we only anti-symmetrise
+            elif 'H_mm' in key.GetName() and 'htt125' in key.GetName() and nxbins>1:
+                hsm = directory.Get(key.GetName().replace('H_mm_','H_sm_'))
+                hps = directory.Get(key.GetName().replace('H_mm_','H_ps_'))
+                histo_asym = ASymmetrise(histo,hsm,hps,nxbins)
+                histo_asym.SetName(histo.GetName()+'_asym')
+                histo_asym.Write()
+                continue 
+
+            # if not mm signal then we always symmetrise
+            else:
+                histo_sym = Symmetrise(histo,nxbins)
+                histo_sym.SetName(histo.GetName()+'_sym')
+                histo_sym.Write()
+
+                # if not signal then we also flatten
+                if 'htt125' not in key.GetName() or 'Higgs_flat' in key.GetName() or 'H_flat' in key.GetName():
+                    histo_flat = MergeXBins(histo,nxbins)
+                    histo_flat.SetName(histo.GetName()+'_flat')
+                    histo_flat.Write()
+
+        ROOT.gDirectory.cd('/')
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--file', '-f', help= 'File from which we want to merge X bins')
+parser.add_argument('--test', '-t', action='store_true', help= 'Run statistical tests on the histograms to check compatability of smoothed and unsmoothed histograms')
+args = parser.parse_args()
+filename = args.file
+newfilename=filename.replace('.root','-mergeXbins.root')
+
+original_file = ROOT.TFile(filename)
+output_file = ROOT.TFile(newfilename,"RECREATE") 
+
+for key in original_file.GetListOfKeys():
+    if isinstance(original_file.Get(key.GetName()),ROOT.TDirectory):
+        dirname=key.GetName()
+        getHistogramAndWriteToFile(original_file,output_file,key.GetName(),dirname)
+
+if args.test:
+    print('Running statistical tests on the histograms to check compatability of smoothed and unsmoothed histograms')
+    for key in output_file.GetListOfKeys():
+        if isinstance(output_file.Get(key.GetName()),ROOT.TDirectory):
+            dirname=key.GetName()
+            directory = output_file.Get(dirname)
+            for subkey in directory.GetListOfKeys():
+                if subkey.endswith('_sym') or subkey.endswith('_flat') or subkey.endswith('_asym'):
+                    continue
+                # skip systematics
+                if subkey.endswith('Up') or subkey.endswith('Down'):
+                    continue
+                
+               
+                histo = directory.Get(subkey.GetName())
+                # check if asym, sym, or flat hitograms exist for this one
+                

--- a/scripts/convertCards.py
+++ b/scripts/convertCards.py
@@ -24,14 +24,27 @@ cp_bins = {
 def MergeXBins(hist, nxbins):
   histnew = hist.Clone()
   nbins = hist.GetNbinsX()
+  chi2_total = 0.
+  ndf_perbin = nxbins-1
+  chi2_perbin=[]
   for i in range(1,nbins+1,nxbins):
     tot_err = c_double(0)
     tot = hist.IntegralAndError(i,i+nxbins-1,tot_err)
     tot_err = tot_err.value
+    ave = tot / nxbins
+    ave_err = tot_err / nxbins
+    chi2 = 0.
     for j in range(i,i+nxbins):
-      histnew.SetBinContent(j,tot/nxbins)
-      histnew.SetBinError(j,tot_err/nxbins)
-  return histnew
+      if hist.GetBinError(j) > 0: chi2 += (hist.GetBinContent(j)-ave)**2 / (hist.GetBinError(j)**2)
+      histnew.SetBinContent(j,ave)
+      histnew.SetBinError(j,ave_err)
+    chi2_perbin.append(chi2)
+  p_val_perbin = [ROOT.TMath.Prob(x, ndf_perbin) for x in chi2_perbin]
+  chi2_total = sum(chi2_perbin)
+  ndf_total = ndf_perbin * len(chi2_perbin)
+  p_val_total = ROOT.TMath.Prob(chi2_total, ndf_total)
+
+  return histnew, p_val_total, p_val_perbin
 
 def Symmetrise(hist,nxbins):
   histnew=hist.Clone()
@@ -40,9 +53,12 @@ def Symmetrise(hist,nxbins):
     print('N X bins in 2D histogram is not even so cannot symmetrise!')
     return
   nybins = int(nbins/nxbins)
+  chi2_perbin = [0 for i in range(nybins)]
+  ndf_perbin = int(nxbins / 2)
   for i in range(1,int(nxbins/2)+1):
     lo_bin = i
     hi_bin = nxbins-i+1
+    chi2 = 0.
     for j in range(1,nybins+1):
       lo_bin_ = lo_bin+(j-1)*nxbins
       hi_bin_ = hi_bin+(j-1)*nxbins
@@ -56,7 +72,16 @@ def Symmetrise(hist,nxbins):
       histnew.SetBinContent(hi_bin_,cnew)
       histnew.SetBinError(lo_bin_,enew)
       histnew.SetBinError(hi_bin_,enew)
-  return histnew
+
+      chi2 = 0.
+      if (e1**2 + e2**2) > 0: chi2 = (c1-c2)**2 / (e1**2 + e2**2)
+      chi2_perbin[j-1] += chi2
+    p_val_perbin = [ ROOT.TMath.Prob(x, ndf_perbin) for x in chi2_perbin]
+    chi2_total = sum(chi2_perbin)
+    ndf_total = ndf_perbin * nybins
+    p_val_total = ROOT.TMath.Prob(chi2_total, ndf_total)
+
+  return histnew, p_val_total, p_val_perbin
 
 def ASymmetrise(hist,hsm,hps,nxbins):
   histnew=hist.Clone()
@@ -136,13 +161,13 @@ def getHistogramAndWriteToFile(infile,outfile,dirname,write_dirname):
 
             # if not mm signal then we always symmetrise
             else:
-                histo_sym = Symmetrise(histo,nxbins)
+                histo_sym, p_val_total, p_val_perbin = Symmetrise(histo,nxbins)
                 histo_sym.SetName(histo.GetName()+'_sym')
                 histo_sym.Write()
 
                 # if not signal then we also flatten
                 if 'htt125' not in key.GetName() or 'Higgs_flat' in key.GetName() or 'H_flat' in key.GetName():
-                    histo_flat = MergeXBins(histo,nxbins)
+                    histo_flat, p_val_total, p_val_perbin = MergeXBins(histo,nxbins)
                     histo_flat.SetName(histo.GetName()+'_flat')
                     histo_flat.Write()
 
@@ -163,20 +188,208 @@ for key in original_file.GetListOfKeys():
         dirname=key.GetName()
         getHistogramAndWriteToFile(original_file,output_file,key.GetName(),dirname)
 
+
+##########
+
+def rescale_chunks(h_toy, h_data, nxbins):
+    nbins = h_toy.GetNbinsX()
+    if nbins != h_data.GetNbinsX():
+        raise ValueError("Histograms must have the same number of bins")
+    
+    for start_bin in range(1, nbins + 1, nxbins):
+        end_bin = min(start_bin + nxbins - 1, nbins)
+
+        # Compute total yield in this chunk
+        sum_data = sum(h_data.GetBinContent(i) for i in range(start_bin, end_bin + 1))
+        sum_toy  = sum(h_toy.GetBinContent(i) for i in range(start_bin, end_bin + 1))
+
+        if sum_toy == 0:
+            continue  # avoid division by zero
+
+        scale_factor = sum_data / sum_toy
+
+        # Rescale h_toy bins in this chunk
+        for i in range(start_bin, end_bin + 1):
+            content = h_toy.GetBinContent(i)
+            error   = h_toy.GetBinError(i)
+
+            h_toy.SetBinContent(i, content * scale_factor)
+            h_toy.SetBinError(i, error * scale_factor)
+
+def chi2_test(h_data, h_model, nxbins=1):
+    h_data = h_data.Clone()
+    h_model = h_model.Clone()
+
+    if h_data.GetNbinsX() != h_model.GetNbinsX():
+        raise ValueError("Histograms must have the same number of bins")
+    
+    chi2_obs = 0.0
+    ndof = 0
+
+    for i in range(1, h_data.GetNbinsX() + 1):  # bin 0 is underflow, skip it
+        D = h_data.GetBinContent(i)
+        M = h_model.GetBinContent(i)
+        sigma = h_data.GetBinError(i)
+
+        if sigma <= 0:
+            continue  # skip bins with zero variance
+
+        chi2_obs += (D - M)**2 / (sigma**2)
+        ndof += 1
+
+    p_value_old = ROOT.TMath.Prob(chi2_obs, ndof)
+
+    # use toys to get p-value
+    n_toys = 1000
+    toys_chi2 = []
+
+    N_err = c_double(0)
+    N = h_data.IntegralAndError(-1,-1, N_err)
+    N_eff = (N/N_err.value)**2
+
+    for t in range(n_toys):
+
+        toy_mode = 1
+
+        h_toy = h_data.Clone()
+        h_toy.Reset()
+        if toy_mode == 1:
+            h_toy.FillRandom(h_model, int(N_eff))
+            h_toy.Scale(h_data.Integral()/h_toy.Integral())
+
+        elif toy_mode == 2:
+            for j in range(1, h_toy.GetNbinsX() + 1):
+                central_value = h_model.GetBinContent(j)
+                random_shift = ROOT.gRandom.Gaus(0, h_data.GetBinError(j)) # random shift based on the error
+                #random_shift = ROOT.gRandom.Gaus(0, h_model.GetBinError(j)) # random shift based on the error
+                h_toy.SetBinContent(j, central_value + random_shift)
+                h_toy.SetBinError(j, h_data.GetBinError(j))
+
+        chi2=0.0
+        for j in range(1, h_toy.GetNbinsX() + 1):
+            if h_toy.GetBinError(j)>0: chi2 += ((h_toy.GetBinContent(j) - h_model.GetBinContent(j))**2)/(h_toy.GetBinError(j)**2)
+        toys_chi2.append(chi2)
+    # p_value = number of times toy chi2 is greater than observed chi2 / total number of toys
+    p_value = sum(1 for toy in toys_chi2 if toy >= chi2_obs) / n_toys
+    print('!!!!', p_value, p_value_old)
+
+    return p_value
+
 if args.test:
+
+    import os
+    if not os.path.exists('test_results'):
+        os.makedirs('test_results')
+
+    def ZeroErrors(hist):
+        for i in range(1,hist.GetNbinsX()+1):
+            hist.SetBinError(i,0.)
+
+    def LastNBinsHistogram(histo, nxbins):
+        total_bins = histo.GetNbinsX()
+        if nxbins > total_bins:
+            raise ValueError(f"Requested {nxbins} bins, but histogram only has {total_bins}.")
+
+        # Create a new histogram with x-axis from 0 to nxbins (arbitrary range)
+        new_histo = ROOT.TH1F(histo.GetName() + "_lastBins", histo.GetTitle(), nxbins, 0, nxbins)
+
+        # Fill the new histogram with the last nxbins from original
+        for i in range(nxbins):
+            orig_bin = total_bins - nxbins + i + 1
+            new_histo.SetBinContent(i + 1, histo.GetBinContent(orig_bin))
+            new_histo.SetBinError(i + 1, histo.GetBinError(orig_bin))
+
+        return new_histo
+
+    def PerformTests(histo, histo_smooth, nxbins=1):
+        #ZeroErrors(histo_smooth)  # zero errors so they aren't counted twice in the test
+        chi2 = histo.Chi2Test(histo_smooth, 'WWCHI2')
+        if chi2 <= 0:
+            chi2_pval = None
+        else:
+            ndf = histo.GetNbinsX()/2
+            chi2_pval = histo.Chi2Test(histo_smooth, 'WW')
+
+        chi2_last_pval = chi2_pval
+
+        #chi2_pval = chi2_test(histo, histo_smooth, nxbins)
+#
+        #if nxbins>1: 
+        #    # make a historam using only the last bins
+        #    histo_last = LastNBinsHistogram(histo, nxbins)
+        #    histo_smooth_last = LastNBinsHistogram(histo_smooth, nxbins)
+        #    chi2_last_pval = chi2_test(histo_last, histo_smooth_last, nxbins)
+        #    #ZeroErrors(histo_smooth_last)  # zero errors so they aren't counted twice in the test
+        #    #chi2_last = histo_last.Chi2Test(histo_smooth_last, 'WWCHI2')
+        #    #if chi2_last<=0: chi2_last_pval = None
+        #    #else: chi2_last_pval = histo_last.Chi2Test(histo_smooth_last, 'WW')
+        #else: chi2_last_pval = chi2_pval
+#
+        ## do chi2 tests for last BDT score bin (most sinal sensitive)
+        ##return (chi2_pval, chi2_last_pval)
+        return (chi2_pval, chi2_last_pval)
+
+    test_results_sym = {}
+    test_results_flat = {}
+    test_results_asym = {}
     print('Running statistical tests on the histograms to check compatability of smoothed and unsmoothed histograms')
     for key in output_file.GetListOfKeys():
         if isinstance(output_file.Get(key.GetName()),ROOT.TDirectory):
             dirname=key.GetName()
             directory = output_file.Get(dirname)
+
+            if dirname in cp_bins: nxbins = cp_bins[dirname]
+            else: nxbins=1
+ 
             for subkey in directory.GetListOfKeys():
-                if subkey.endswith('_sym') or subkey.endswith('_flat') or subkey.endswith('_asym'):
+                if subkey.GetName().endswith('_sym') or subkey.GetName().endswith('_flat') or subkey.GetName().endswith('_asym'):
                     continue
                 # skip systematics
-                if subkey.endswith('Up') or subkey.endswith('Down'):
+                if subkey.GetName().endswith('Up') or subkey.GetName().endswith('Down'):
                     continue
-                
+
+                if 'unfiltered' in subkey.GetName(): continue
+
+                if not ('ggH' in subkey.GetName() or 'qqH' in subkey.GetName() or 'ZTT' in subkey.GetName() or 'QCD' in subkey.GetName()): continue 
                
+                if 'prod_ps' in subkey.GetName() or 'prod_mm' in subkey.GetName():
+                    continue
+
+                print('Performing tests on:', dirname, subkey.GetName())
+
                 histo = directory.Get(subkey.GetName())
-                # check if asym, sym, or flat hitograms exist for this one
-                
+                histo_sym = directory.Get(subkey.GetName()+'_sym')
+                histo_flat = directory.Get(subkey.GetName()+'_flat')
+                histo_asym = directory.Get(subkey.GetName()+'_asym')
+
+                if histo_sym and 'flat' not in subkey.GetName():
+                    if 'H_ps' in subkey.GetName(): continue # since we use reweighting we don't do the test for both sm and ps
+                    test_results = PerformTests(histo, histo_sym, nxbins)
+                    if dirname not in test_results_sym:
+                        test_results_sym[dirname] = {}
+                    test_results_sym[dirname][subkey.GetName()] = test_results
+    #            if histo_flat: 
+    #                test_results = PerformTests(histo, histo_flat, nxbins)
+    #                if dirname not in test_results_flat:
+    #                    test_results_flat[dirname] = {}
+    #                test_results_flat[dirname][subkey.GetName()] = test_results
+#
+    #            if histo_asym and 'flat' not in subkey.GetName():
+    #                test_results = PerformTests(histo, histo_asym, nxbins)
+    #                if dirname not in test_results_asym:
+    #                    test_results_asym[dirname] = {}
+    #                test_results_asym[dirname][subkey.GetName()] = test_results
+
+    print('\n\nResults of the tests for symmetrised histograms:')
+    for dirname, results in test_results_sym.items():
+        print(f"Directory: {dirname}")
+        for histo_name, (chi2_pval, chi2_last_pval) in results.items():
+            print(f"  Histogram: {histo_name}, Chi2 p-value: {chi2_pval}, Last bin Chi2 p-value: {chi2_last_pval}")
+    #print('\n\nResults of the tests for flattened histograms:')
+    #for dirname, results in test_results_flat.items():
+    #    print(f"Directory: {dirname}")
+    #    for histo_name, (chi2_pval, chi2_last_pval) in results.items():
+    #        print(f"  Histogram: {histo_name}, Chi2 p-value: {chi2_pval}, Last bin Chi2 p-value: {chi2_last_pval}")
+
+
+

--- a/scripts/convertCards.py
+++ b/scripts/convertCards.py
@@ -161,7 +161,7 @@ def getHistogramAndWriteToFile(infile,outfile,dirname,write_dirname):
                 hsm = directory.Get(key.GetName().replace('H_mm_','H_sm_'))
                 hps = directory.Get(key.GetName().replace('H_mm_','H_ps_'))
                 histo_asym = ASymmetrise(histo,hsm,hps,nxbins)
-                histo_asym.SetName(histo.GetName()+'_asym')
+                histo_asym.SetName(histo.GetName()+'_sym')
                 histo_asym.Write()
                 continue 
 
@@ -281,11 +281,11 @@ if args.test:
     hist_sym_last_1d.Sumw2()
     hist_flat_last_1d.Sumw2()
 
-    print('\n\nSymmetrisation test results:')
+    #print('\n\nSymmetrisation test results:')
     i = 0
     for dirname, results in test_results_sym.items():
         i+=1
-        print(f'Directory: {dirname}')
+        #print(f'Directory: {dirname}')
         # set x-labels
         hist_sym_2d.GetXaxis().SetBinLabel(i, dirname)
         hist_sym_last_2d.GetXaxis().SetBinLabel(i, dirname)
@@ -314,11 +314,11 @@ if args.test:
               hist_sym_1d.Fill(p_val_total)
               hist_sym_last_1d.Fill(p_val_last)
 
-    print('\n\nFlattening test results:')
+    #print('\n\nFlattening test results:')
     i=0
     for dirname, results in test_results_flat.items():
         i+=1
-        print(f'Directory: {dirname}')
+        #print(f'Directory: {dirname}')
         # set x-labels
         hist_flat_2d.GetXaxis().SetBinLabel(i, dirname)
         hist_flat_last_2d.GetXaxis().SetBinLabel(i, dirname)

--- a/scripts/convertCards.py
+++ b/scripts/convertCards.py
@@ -3,6 +3,7 @@ import math
 import argparse
 ROOT.TH1.AddDirectory(False)
 from ctypes import c_double
+import os
  
 # note that the merging of bins requires an even numnber of phi_CP bins, and this number must be set to the specific value used in the dictionary below otherwise the method will give incorrect results!
 
@@ -20,6 +21,10 @@ cp_bins = {
         "tt_higgs_rhoa11pr" : 4,
         "tt_higgs_rhorho" : 10,
 }
+
+test_results_sym = {}
+test_results_flat = {}
+test_results_asym = {}
 
 def MergeXBins(hist, nxbins):
   histnew = hist.Clone()
@@ -43,6 +48,9 @@ def MergeXBins(hist, nxbins):
   chi2_total = sum(chi2_perbin)
   ndf_total = ndf_perbin * len(chi2_perbin)
   p_val_total = ROOT.TMath.Prob(chi2_total, ndf_total)
+
+  print(f'Chi2 total: {chi2_total}, NDF total: {ndf_total}, P-value total: {p_val_total:.4f}')
+  print(f'Chi2 per bin: {chi2_perbin}, P-value per bin: {p_val_perbin}')
 
   return histnew, p_val_total, p_val_perbin
 
@@ -162,12 +170,18 @@ def getHistogramAndWriteToFile(infile,outfile,dirname,write_dirname):
             # if not mm signal then we always symmetrise
             else:
                 histo_sym, p_val_total, p_val_perbin = Symmetrise(histo,nxbins)
+                if dirname not in test_results_sym:
+                    test_results_sym[dirname] = {}
+                test_results_sym[dirname][histo.GetName()] = (p_val_total, p_val_perbin[-1])
                 histo_sym.SetName(histo.GetName()+'_sym')
                 histo_sym.Write()
 
                 # if not signal then we also flatten
                 if 'htt125' not in key.GetName() or 'Higgs_flat' in key.GetName() or 'H_flat' in key.GetName():
                     histo_flat, p_val_total, p_val_perbin = MergeXBins(histo,nxbins)
+                    if dirname not in test_results_flat:
+                        test_results_flat[dirname] = {}
+                    test_results_flat[dirname][histo.GetName()] = (p_val_total, p_val_perbin[-1])
                     histo_flat.SetName(histo.GetName()+'_flat')
                     histo_flat.Write()
 
@@ -188,208 +202,24 @@ for key in original_file.GetListOfKeys():
         dirname=key.GetName()
         getHistogramAndWriteToFile(original_file,output_file,key.GetName(),dirname)
 
-
-##########
-
-def rescale_chunks(h_toy, h_data, nxbins):
-    nbins = h_toy.GetNbinsX()
-    if nbins != h_data.GetNbinsX():
-        raise ValueError("Histograms must have the same number of bins")
-    
-    for start_bin in range(1, nbins + 1, nxbins):
-        end_bin = min(start_bin + nxbins - 1, nbins)
-
-        # Compute total yield in this chunk
-        sum_data = sum(h_data.GetBinContent(i) for i in range(start_bin, end_bin + 1))
-        sum_toy  = sum(h_toy.GetBinContent(i) for i in range(start_bin, end_bin + 1))
-
-        if sum_toy == 0:
-            continue  # avoid division by zero
-
-        scale_factor = sum_data / sum_toy
-
-        # Rescale h_toy bins in this chunk
-        for i in range(start_bin, end_bin + 1):
-            content = h_toy.GetBinContent(i)
-            error   = h_toy.GetBinError(i)
-
-            h_toy.SetBinContent(i, content * scale_factor)
-            h_toy.SetBinError(i, error * scale_factor)
-
-def chi2_test(h_data, h_model, nxbins=1):
-    h_data = h_data.Clone()
-    h_model = h_model.Clone()
-
-    if h_data.GetNbinsX() != h_model.GetNbinsX():
-        raise ValueError("Histograms must have the same number of bins")
-    
-    chi2_obs = 0.0
-    ndof = 0
-
-    for i in range(1, h_data.GetNbinsX() + 1):  # bin 0 is underflow, skip it
-        D = h_data.GetBinContent(i)
-        M = h_model.GetBinContent(i)
-        sigma = h_data.GetBinError(i)
-
-        if sigma <= 0:
-            continue  # skip bins with zero variance
-
-        chi2_obs += (D - M)**2 / (sigma**2)
-        ndof += 1
-
-    p_value_old = ROOT.TMath.Prob(chi2_obs, ndof)
-
-    # use toys to get p-value
-    n_toys = 1000
-    toys_chi2 = []
-
-    N_err = c_double(0)
-    N = h_data.IntegralAndError(-1,-1, N_err)
-    N_eff = (N/N_err.value)**2
-
-    for t in range(n_toys):
-
-        toy_mode = 1
-
-        h_toy = h_data.Clone()
-        h_toy.Reset()
-        if toy_mode == 1:
-            h_toy.FillRandom(h_model, int(N_eff))
-            h_toy.Scale(h_data.Integral()/h_toy.Integral())
-
-        elif toy_mode == 2:
-            for j in range(1, h_toy.GetNbinsX() + 1):
-                central_value = h_model.GetBinContent(j)
-                random_shift = ROOT.gRandom.Gaus(0, h_data.GetBinError(j)) # random shift based on the error
-                #random_shift = ROOT.gRandom.Gaus(0, h_model.GetBinError(j)) # random shift based on the error
-                h_toy.SetBinContent(j, central_value + random_shift)
-                h_toy.SetBinError(j, h_data.GetBinError(j))
-
-        chi2=0.0
-        for j in range(1, h_toy.GetNbinsX() + 1):
-            if h_toy.GetBinError(j)>0: chi2 += ((h_toy.GetBinContent(j) - h_model.GetBinContent(j))**2)/(h_toy.GetBinError(j)**2)
-        toys_chi2.append(chi2)
-    # p_value = number of times toy chi2 is greater than observed chi2 / total number of toys
-    p_value = sum(1 for toy in toys_chi2 if toy >= chi2_obs) / n_toys
-    print('!!!!', p_value, p_value_old)
-
-    return p_value
-
 if args.test:
-
-    import os
     if not os.path.exists('test_results'):
         os.makedirs('test_results')
 
-    def ZeroErrors(hist):
-        for i in range(1,hist.GetNbinsX()+1):
-            hist.SetBinError(i,0.)
-
-    def LastNBinsHistogram(histo, nxbins):
-        total_bins = histo.GetNbinsX()
-        if nxbins > total_bins:
-            raise ValueError(f"Requested {nxbins} bins, but histogram only has {total_bins}.")
-
-        # Create a new histogram with x-axis from 0 to nxbins (arbitrary range)
-        new_histo = ROOT.TH1F(histo.GetName() + "_lastBins", histo.GetTitle(), nxbins, 0, nxbins)
-
-        # Fill the new histogram with the last nxbins from original
-        for i in range(nxbins):
-            orig_bin = total_bins - nxbins + i + 1
-            new_histo.SetBinContent(i + 1, histo.GetBinContent(orig_bin))
-            new_histo.SetBinError(i + 1, histo.GetBinError(orig_bin))
-
-        return new_histo
-
-    def PerformTests(histo, histo_smooth, nxbins=1):
-        #ZeroErrors(histo_smooth)  # zero errors so they aren't counted twice in the test
-        chi2 = histo.Chi2Test(histo_smooth, 'WWCHI2')
-        if chi2 <= 0:
-            chi2_pval = None
-        else:
-            ndf = histo.GetNbinsX()/2
-            chi2_pval = histo.Chi2Test(histo_smooth, 'WW')
-
-        chi2_last_pval = chi2_pval
-
-        #chi2_pval = chi2_test(histo, histo_smooth, nxbins)
-#
-        #if nxbins>1: 
-        #    # make a historam using only the last bins
-        #    histo_last = LastNBinsHistogram(histo, nxbins)
-        #    histo_smooth_last = LastNBinsHistogram(histo_smooth, nxbins)
-        #    chi2_last_pval = chi2_test(histo_last, histo_smooth_last, nxbins)
-        #    #ZeroErrors(histo_smooth_last)  # zero errors so they aren't counted twice in the test
-        #    #chi2_last = histo_last.Chi2Test(histo_smooth_last, 'WWCHI2')
-        #    #if chi2_last<=0: chi2_last_pval = None
-        #    #else: chi2_last_pval = histo_last.Chi2Test(histo_smooth_last, 'WW')
-        #else: chi2_last_pval = chi2_pval
-#
-        ## do chi2 tests for last BDT score bin (most sinal sensitive)
-        ##return (chi2_pval, chi2_last_pval)
-        return (chi2_pval, chi2_last_pval)
-
-    test_results_sym = {}
-    test_results_flat = {}
-    test_results_asym = {}
-    print('Running statistical tests on the histograms to check compatability of smoothed and unsmoothed histograms')
-    for key in output_file.GetListOfKeys():
-        if isinstance(output_file.Get(key.GetName()),ROOT.TDirectory):
-            dirname=key.GetName()
-            directory = output_file.Get(dirname)
-
-            if dirname in cp_bins: nxbins = cp_bins[dirname]
-            else: nxbins=1
- 
-            for subkey in directory.GetListOfKeys():
-                if subkey.GetName().endswith('_sym') or subkey.GetName().endswith('_flat') or subkey.GetName().endswith('_asym'):
-                    continue
-                # skip systematics
-                if subkey.GetName().endswith('Up') or subkey.GetName().endswith('Down'):
-                    continue
-
-                if 'unfiltered' in subkey.GetName(): continue
-
-                if not ('ggH' in subkey.GetName() or 'qqH' in subkey.GetName() or 'ZTT' in subkey.GetName() or 'QCD' in subkey.GetName()): continue 
-               
-                if 'prod_ps' in subkey.GetName() or 'prod_mm' in subkey.GetName():
-                    continue
-
-                print('Performing tests on:', dirname, subkey.GetName())
-
-                histo = directory.Get(subkey.GetName())
-                histo_sym = directory.Get(subkey.GetName()+'_sym')
-                histo_flat = directory.Get(subkey.GetName()+'_flat')
-                histo_asym = directory.Get(subkey.GetName()+'_asym')
-
-                if histo_sym and 'flat' not in subkey.GetName():
-                    if 'H_ps' in subkey.GetName(): continue # since we use reweighting we don't do the test for both sm and ps
-                    test_results = PerformTests(histo, histo_sym, nxbins)
-                    if dirname not in test_results_sym:
-                        test_results_sym[dirname] = {}
-                    test_results_sym[dirname][subkey.GetName()] = test_results
-    #            if histo_flat: 
-    #                test_results = PerformTests(histo, histo_flat, nxbins)
-    #                if dirname not in test_results_flat:
-    #                    test_results_flat[dirname] = {}
-    #                test_results_flat[dirname][subkey.GetName()] = test_results
-#
-    #            if histo_asym and 'flat' not in subkey.GetName():
-    #                test_results = PerformTests(histo, histo_asym, nxbins)
-    #                if dirname not in test_results_asym:
-    #                    test_results_asym[dirname] = {}
-    #                test_results_asym[dirname][subkey.GetName()] = test_results
-
-    print('\n\nResults of the tests for symmetrised histograms:')
+    print('\n\nSymmetrisation test results:')
     for dirname, results in test_results_sym.items():
-        print(f"Directory: {dirname}")
-        for histo_name, (chi2_pval, chi2_last_pval) in results.items():
-            print(f"  Histogram: {histo_name}, Chi2 p-value: {chi2_pval}, Last bin Chi2 p-value: {chi2_last_pval}")
-    #print('\n\nResults of the tests for flattened histograms:')
-    #for dirname, results in test_results_flat.items():
-    #    print(f"Directory: {dirname}")
-    #    for histo_name, (chi2_pval, chi2_last_pval) in results.items():
-    #        print(f"  Histogram: {histo_name}, Chi2 p-value: {chi2_pval}, Last bin Chi2 p-value: {chi2_last_pval}")
+        print(f'Directory: {dirname}')
+        for hist_name, (p_val_total, p_val_last) in results.items():
+            if not(hist_name in ['QCD', 'ZTT'] or hist_name.startswith('ggH_sm') or hist_name.startswith('qqH_sm')) or 'unfiltered' in hist_name: continue
+            print(f'  Histogram: {hist_name}, P-value total: {p_val_total:.4f}, P-value last bin: {p_val_last:.4f}')
+
+
+    print('\n\nFlattening test results:')
+    for dirname, results in test_results_flat.items():
+        print(f'Directory: {dirname}')
+        for hist_name, (p_val_total, p_val_last) in results.items():
+            if hist_name not in ['QCD', 'ZTT', 'qqH_flat_htt125', 'ggH_flat_prod_sm_htt125']: continue
+            print(f'  Histogram: {hist_name}, P-value total: {p_val_total:.4f}, P-value last bin: {p_val_last:.4f}')
 
 
 

--- a/scripts/harvestDatacards.py
+++ b/scripts/harvestDatacards.py
@@ -128,8 +128,6 @@ for chn in chans:
 
 ch.SetStandardBinNames(cb)
 
-#TODO: setup bbb's here
-
 def MatchingProcess(first, second):
     return (
         first.bin()      == second.bin() and

--- a/scripts/harvestDatacards.py
+++ b/scripts/harvestDatacards.py
@@ -20,7 +20,8 @@ else: chans = chans.split(',')
 
 output_folder = setup['output_folder']
 input_folder = setup['input_folder']
-mergeSymBins = setup['mergeSymBins'] # use this option to specify if we want to flatten and/or symmetrise distributions
+merge_mode = setup['merge_mode'] # use this option to specify if we want to flatten and/or symmetrise distributions
+# 0: no merging, 1: merge symmetrised bins, 2: Run-2 style merging
 # TODO: implement this in this script based on the extracted shapes rather than using the additional pre-processing step as we did for Run-2
 
 Run2 = False
@@ -90,26 +91,149 @@ for chn in chans:
 # TODO: systematics to be added here
 cb = AddSMRun3Systematics(cb)
 
-# Populating Observation, Process and Systematic entries in the harvester instance
+if merge_mode == 2:
+    flat_cats = ['tt_higgs_rhorho', 'tt_higgs_rhoa11pr', 'tt_higgs_rhoa1', 'tt_higgs_pirho', 'tt_higgs_pia11pr', 'tt_higgs_a11pra1']
+    sym_cats = ['tt_higgs_a1a1', 'tt_higgs_pipi', 'tt_higgs_pia1']
+elif merge_mode == 1: 
+    flat_cats = []
+    sym_cats = ['tt_higgs_rhorho', 'tt_higgs_rhoa11pr', 'tt_higgs_rhoa1', 'tt_higgs_pirho', 'tt_higgs_pia11pr', 'tt_higgs_a11pra1', 'tt_higgs_a1a1', 'tt_higgs_pipi', 'tt_higgs_pia1']
+else:
+    flat_cats = []
+    sym_cats = []
+
+## Populating Observation, Process and Systematic entries in the harvester instance
+
 for chn in chans:
     if Run2: filename = '%s/htt_%s.inputs-sm-13TeV.root' % (input_folder,chn)
-    else: filename = '%s/added_histo_Run2Bins.root' % (input_folder)
+    else: filename = '%s/added_histo_Run2Bins-mergeXbins.root' % (input_folder)
     print (">>>   file %s" % (filename))
-    cb.cp().channel([chn]).process(bkg_procs).era(['13p6TeV']).ExtractShapes(filename, "$BIN/$PROCESS", "$BIN/$PROCESS_$SYSTEMATIC")
-    for sig_proc in sig_procs.values(): 
-        cb.cp().channel([chn]).process(sig_proc).era(['13p6TeV']).ExtractShapes(filename, "$BIN/$PROCESS$MASS", "$BIN/$PROCESS$MASS_$SYSTEMATIC")
+    cb.cp().channel([chn]).backgrounds().process(['ZL']).era(['13p6TeV']).ExtractShapes(filename, "$BIN/$PROCESS", "$BIN/$PROCESS_$SYSTEMATIC") # add data shapes
+    if merge_mode == 0: 
+        cb.cp().channel([chn]).process(bkg_procs).era(['13p6TeV']).ExtractShapes(filename, "$BIN/$PROCESS", "$BIN/$PROCESS_$SYSTEMATIC")
+        for sig_proc in sig_procs.values(): cb.cp().channel([chn]).process(sig_proc).era(['13p6TeV']).ExtractShapes(filename, "$BIN/$PROCESS$MASS", "$BIN/$PROCESS$MASS_$SYSTEMATIC")
+    else:
+        for cat in cats[chn]:
+            if cat[1] in flat_cats:
+                cb.cp().channel([chn]).bin_id([cat[0]]).process(bkg_procs).process(['QCD'],False).era(['13p6TeV']).ExtractShapes(filename, "$BIN/$PROCESS_flat", "$BIN/$PROCESS_$SYSTEMATIC_flat")
+                # jetFakes and signal are symmetrised rather than flattened
+                cb.cp().channel([chn]).bin_id([cat[0]]).process(bkg_procs).process(['QCD']).era(['13p6TeV']).ExtractShapes(filename, "$BIN/$PROCESS_sym", "$BIN/$PROCESS_$SYSTEMATIC_sym")
+                for sig_proc in sig_procs.values(): cb.cp().channel([chn]).process(sig_proc).era(['13p6TeV']).ExtractShapes(filename, "$BIN/$PROCESS$MASS_sym", "$BIN/$PROCESS$MASS_$SYSTEMATIC_sym")
+            elif cat[1] in sym_cats:
+                cb.cp().channel([chn]).bin_id([cat[0]]).process(bkg_procs).era(['13p6TeV']).ExtractShapes(filename, "$BIN/$PROCESS_sym", "$BIN/$PROCESS_$SYSTEMATIC_sym")
+                for sig_proc in sig_procs.values(): cb.cp().channel([chn]).process(sig_proc).era(['13p6TeV']).ExtractShapes(filename, "$BIN/$PROCESS$MASS_sym", "$BIN/$PROCESS$MASS_$SYSTEMATIC_sym")
+            else:
+                cb.cp().channel([chn]).bin_id([cat[0]]).process(bkg_procs).era(['13p6TeV']).ExtractShapes(filename, "$BIN/$PROCESS", "$BIN/$PROCESS_$SYSTEMATIC")
+                for sig_proc in sig_procs.values(): cb.cp().channel([chn]).bin_id([cat[0]]).process(sig_proc).era(['13p6TeV']).ExtractShapes(filename, "$BIN/$PROCESS$MASS", "$BIN/$PROCESS$MASS_$SYSTEMATIC")
 
 ch.SetStandardBinNames(cb)
 
 #TODO: setup bbb's here
 
-if not mergeSymBins:
+def MatchingProcess(first, second):
+    return (
+        first.bin()      == second.bin() and
+        first.process()  == second.process() and
+        first.signal()   == second.signal() and
+        first.analysis() == second.analysis() and
+        first.era()      == second.era() and
+        first.channel()  == second.channel() and
+        first.bin_id()   == second.bin_id() and
+        first.mass()     == second.mass()
+    )
+
+if merge_mode == 0:
     # If not flattening/symmetrising then add bbb uncerts using autoMC stats
     cb.SetAutoMCStats(cb, 0., 1, 1)
-#else:
+else:
+    cb.cp().bin_id([1,2]).SetAutoMCStats(cb, 0., 1, 1) # use ausoMCstats for background categories since these don't merge bins
     # if not then use old method for BBBs to allow correlations to be taken into account
     # TODO: We could ask combine experts if it is possible to modify autoMCStats to allow for correlations which should be faster 
     # TODO: implement old method for BBBs
+
+    #bbb_fakes = ch.BinByBinFactory()
+    #bbb_fakes.SetPattern("CMS_$ANALYSIS_$CHANNEL_$BIN_$ERA_$PROCESS_bbb_bin_$#") # this needs to have "_bbb_bin_" in the pattern for the mergeXbbb option to work
+    #bbb_fakes.SetAddThreshold(0.)
+    #bbb_fakes.SetMergeThreshold(0.5)
+    #bbb_fakes.SetFixNorm(False)
+    #bbb_fakes.MergeBinErrors(cb.cp().bin_id([1,2], False).backgrounds().process(['QCD']))
+    #bbb_fakes.AddBinByBin(cb.cp().bin_id([1,2], False).backgrounds().process(['QCD']), cb)
+
+    bbb_real = ch.BinByBinFactory()
+    bbb_real.SetPattern("CMS_$ANALYSIS_$CHANNEL_$BIN_$ERA_$PROCESS_bbb_bin_$#") # this needs to have "_bbb_bin_" in the pattern for the mergeXbbb option to work
+    bbb_real.SetAddThreshold(0.)
+    #bbb_real.SetMergeThreshold(0.5)
+    bbb_real.SetMergeThreshold(1.0)
+    bbb_real.SetFixNorm(False)
+    #bbb_real.MergeBinErrors(cb.cp().bin_id([1,2], False).backgrounds().process(['ZTT']).process(['QCD'],False))
+    #bbb_real.AddBinByBin(cb.cp().bin_id([1,2], False).backgrounds().process(['ZTT']).process(['QCD'],False), cb)
+    bbb_real.MergeBinErrors(cb.cp().backgrounds().process(['QCD'],False))
+    bbb_real.AddBinByBin(cb.cp().backgrounds().process(['QCD'],False), cb)
+
+
+    # As we merged the x-axis bins then we need to rename the bbb uncertainties so that they are correlated properly
+    # First we will deal with the catogiries with flat background when all phi_CP bins are merged into 1
+    # we need to hardcode the bin number for the xbins
+    # Each vector element i corresponds to the number of xbins for bin i+1
+    # If these numbers aren't set correctly the method won't work so be careful!
+    # Note that the merging is now only performed for the templates that have a flat distribution
+
+    tt_nxbins = [1, 1, 10, 4, 4, 1, 10, 1, 1, 4, 4]  # tt channel binning, set to 1 if no flattening is applied
+    mt_nxbins = [1, 1, 10, 1, 4, 4]                 # mt (and et) channel binning, set to 1 if no flattening is applied
+
+    for chan in chans:
+        bins = tt_nxbins if ch == "tt" else mt_nxbins
+        for i, nxbins in enumerate(bins):
+            if nxbins <= 1:
+                continue
+            print(f"Merging bbb uncertainties for {chan} channel for category {i+1}, nxbins set to {nxbins}")
+
+            def process_callback(proc):
+                nominal = proc.ClonedShape().Clone()
+
+                def syst_callback(syst):
+                    old_name = syst.name()
+                    match_proc = MatchingProcess(proc, syst)
+
+                    if match_proc and "_bbb_bin_" in old_name:
+                        bin_num = int(old_name.split('_bbb_bin_')[-1])
+
+                        if (bin_num-1) % nxbins == 0:
+                            print('bin_num again:', bin_num)
+                            nonum_name = old_name.replace(f"_bbb_bin_{bin_num}", '_bbb_bin_')
+                            shape_u_new = syst.ClonedShapeU().Clone()
+                            shape_d_new = syst.ClonedShapeD().Clone()
+                            shape_u_new.Scale(syst.value_u()) ###
+                            shape_d_new.Scale(syst.value_d()) ###
+                            shape_u_new.Add(nominal, -1)
+                            shape_d_new.Add(nominal, -1)
+                            names = []
+                            for j in range(bin_num + 1, bin_num + nxbins):
+                                names.append(f"{nonum_name}{j}")
+
+                            def merge_syst_shapes(s):
+                                shape_u_temp = s.ClonedShapeU().Clone()
+                                shape_d_temp = s.ClonedShapeD().Clone()
+                                shape_u_temp.Scale(s.value_u()) ###
+                                shape_d_temp.Scale(s.value_d()) ###
+                                shape_u_temp.Add(nominal, -1)
+                                shape_d_temp.Add(nominal, -1)
+                                shape_u_new.Add(shape_u_temp)
+                                shape_d_new.Add(shape_d_temp)
+
+                            cb.cp().syst_name(names).ForEachSyst(merge_syst_shapes)
+
+                            shape_u_new.Add(nominal)
+                            shape_d_new.Add(nominal)
+
+                            syst.set_shapes(shape_u_new, shape_d_new, nominal)
+                            
+                            for n in names:
+                                cb.FilterSysts(lambda s: s.name() == n)
+                            
+                cb.cp().ForEachSyst(syst_callback)
+
+            #cb.cp().channel([chan]).bin_id([i+1]).backgrounds().process(["QCD"], False).ForEachProc(process_callback)
+            #TODO: need to see why the process where everything gets merged into appears to be random
 
 
 # Implement fixes for negative bins and yields


### PR DESCRIPTION
- adding script to produce smoothed templates for each process 
- symmetrised templates have postfit "_sym"
- flattened templates have postfit "_flat"
- merge_bins option added to harvesting step which determines if smoothed templates are used. 0: no smoothing, 1: symmetrising all templates: 2: Run-2 style (some templates flattened, others symmetrised)
- if smoothed templates are used, the the bbb's are added using other method (i.e not using autoMCstats)
- then correlations between merged bins are handled properly by merging and renaming bbb uncertainties